### PR TITLE
Prise en compte des erreurs liées au dictionnaires

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,11 @@
         </div>
         <main class="app__content" onclick="">
           <article class="dict-content js-dict-content"></article>
+          <div class="dict-error js-dict-error">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path d="M12 22C6.477 22 2 17.523 2 12S6.477 2 12 2s10 4.477 10 10-4.477 10-10 10zm-1-7v2h2v-2h-2zm0-8v6h2V7h-2z"/></svg>
+            <strong>Le terme est introuvable, ou une autre erreur s'est produite.</strong>
+            <br>Vérifiez votre recherche (incluant les espaces superflus) et réessayez.
+          </div>
         </main>
       </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -6,6 +6,7 @@ var appBackButton = document.querySelector(".js-back-button");
 var appForwardButton = document.querySelector(".js-forward-button");
 var appMainSearch = document.querySelector(".js-app-main-search");
 var dictContentHolder = document.querySelector(".js-dict-content");
+var dictError = document.querySelector(".js-dict-error")
 
 var setLoadProgress = percent => {
   percent === 100 ? appProgressBar.classList.remove("visible") : appProgressBar.classList.add("visible");
@@ -14,16 +15,22 @@ var setLoadProgress = percent => {
 
 var getArticle = article => {
   dictContentHolder.innerHTML = "";
+  dictError.style.display = "none";
   setLoadProgress(50);
-  fetch(`https://cors-anywhere.glitch.me/www.cnrtl.fr/definition/${article}`).
-  then(response => response.text()).
-  then(responseText => domParser.parseFromString(responseText, "text/html")).
-  then(responseDOM => {
+  fetch(`https://cors-anywhere.glitch.me/www.cnrtl.fr/definition/${article}`)
+  .then(response => response.text())
+  .then(responseText => domParser.parseFromString(responseText, "text/html"))
+  .then(responseDOM => {
     setLoadProgress(90);
-    console.log(responseDOM);
-    var dictContent = responseDOM.getElementById("lexicontent").outerHTML || responseDOM.getElementById("contentbox").outerHTML;
-    dictContentHolder.innerHTML = dictContent;
+    return responseDOM.getElementById("lexicontent").outerHTML;
+  })
+  .then(responseDictContent => {
+    dictContentHolder.innerHTML = responseDictContent;
     setLoadProgress(100);
+  })
+  .catch(() => {
+    setLoadProgress(100);
+    dictError.style.display = "flex";
   });
 };
 

--- a/style.css
+++ b/style.css
@@ -162,8 +162,19 @@ svg {
   padding: 5px 15px;
 }
 
-.dict-content--error {
+.dict-error {
+  display: none;
+  flex-direction: column;
+  align-items: center;
   margin: auto;
+  text-align: center;
+}
+
+.dict-error svg {
+  display: block;
+  width: 80px;
+  height: 80px;
+  opacity: 0.3;
 }
 
 /* Contenu dictionnaire - adapté du code de cnrtl.fr */


### PR DESCRIPTION
Prise en compte des erreurs quand un élément `lexicontent` ne peut pas être trouvé sur les résultats du CNRTL, ce qui signifie la plupart du temps que le terme est introuvable.

Fix #1 